### PR TITLE
Update forwarder.php

### DIFF
--- a/data/gateways/stripe.com/forwarder.php
+++ b/data/gateways/stripe.com/forwarder.php
@@ -42,7 +42,7 @@
       ],
       'mode' => 'payment',
       'success_url' => $forwardURL.'&s=100',                // redirect on success
-      'cancel_url' => $forwardURL.'&s=99'                   // redirect on cancel
+      'cancel_url' => $SITE                                 // redirect on cancel
     ]);
 
     header("Location: " .$checkout_session->url);


### PR DESCRIPTION
changed the cancel url to the root page to avoid malicious users from emptying a store's inventory.